### PR TITLE
Add test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ composer require macocci7/bash-colorizer
 |`conceal`|〇|〇|
 |`strike`|〇|〇|
 |`gothic`|❌|❌|
-|`double-underl ine`|〇|〇|
+|`double-underline`|〇|〇|
 |`normal`|〇|〇|
 |`no-italic`|〇|〇|
 |`no-underline`|〇|〇|

--- a/src/Colorizer.php
+++ b/src/Colorizer.php
@@ -25,10 +25,10 @@ class Colorizer
     }
 
     /**
-     * @param   string[]|null   $attributes = []
+     * @param   string[]|Attribute[]|null   $attributes = []
      * @return  string[]|null|self
      */
-    public static function attributes(array|null $attributes = []): array|null|self
+    public static function attributes(array|null $attributes = null): array|null|self
     {
         if (is_null($attributes)) {
             return self::$config['attributes'] ?? null;
@@ -41,10 +41,11 @@ class Colorizer
 
     /**
      * @param   string|Foreground|int|int[]|null $foreground = null
-     * @return  string|int|int[]|null|self
+     * @return  string|Foreground|int|int[]|null|self
      */
-    public static function foreground(string|Foreground|int|array|null $foreground = null): string|int|array|null|self
-    {
+    public static function foreground(
+        string|Foreground|int|array|null $foreground = null
+    ): string|Foreground|int|array|null|self {
         if (is_null($foreground)) {
             return self::$config['foreground'] ?? null;
         }
@@ -54,10 +55,11 @@ class Colorizer
 
     /**
      * @param   string|Background|int|int[]|null $background = null
-     * @return  string|int|int[]|null|self
+     * @return  string|Background|int|int[]|null|self
      */
-    public static function background(string|Background|int|array|null $background = null): string|int|array|null|self
-    {
+    public static function background(
+        string|Background|int|array|null $background = null
+    ): string|Background|int|array|null|self {
         if (is_null($background)) {
             return self::$config['background'] ?? null;
         }
@@ -194,10 +196,11 @@ class Colorizer
 
     public static function encode(string $string, string $eol = ''): string
     {
-        return sprintf(
+        $codes = static::codes(static::$config);
+        return empty($codes) ? $string : sprintf(
             '%s[%sm%s%s[m%s',
             static::ESC,
-            static::codes(static::$config),
+            $codes,
             $string,
             static::ESC,
             $eol,

--- a/tests/ColorizerTest.php
+++ b/tests/ColorizerTest.php
@@ -13,6 +13,109 @@ use Macocci7\BashColorizer\Enums\Background;
 
 final class ColorizerTest extends TestCase
 {
+    public static function provide_config_can_set_config_correctly(): array
+    {
+        return [
+            'case 1' => [
+                'config' => [],
+            ],
+            'case 2' => [
+                'config' => [0],
+            ],
+            'case 3' => [
+                'config' => ['attributes' => null],
+            ],
+            'case 4' => [
+                'config' => ['attributes' => ["bold", "italic"]],
+            ],
+            'case 5' => [
+                'config' => [
+                    'attributes' => ["bold", "italic"],
+                    'forground' => "yellow",
+                ],
+            ],
+            'case 6' => [
+                'config' => [
+                    'attributes' => ["bold", "italic"],
+                    'forground' => "yellow",
+                    'background' => "blue",
+                ],
+            ],
+            'case 7' => [
+                'config' => [
+                    'attributes' => ["bold", "italic"],
+                    'forground' => "yellow",
+                    'background' => "blue",
+                    'unnecessary' => "hello",
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provide_config_can_set_config_correctly')]
+    public function test_config_can_set_config_correctly(array $config): void
+    {
+        $this->assertSame($config, Colorizer::config($config)->config());
+    }
+
+    public static function provide_attributes_can_set_attributes_correctly(): array
+    {
+        return [
+            '[]' => ['attributes' => []],
+            '[null]' => ['attributes' => [null]],
+            '[0]' => ['attributes' => [0]],
+            '["bold"]' => ['attributes' => ["bold"]],
+            '[Attribute::Bold]' => ['attributes' => [Attribute::Bold]],
+            '["bold", "italic"]' => ['attributes' => ["bold", "italic"]],
+        ];
+    }
+
+    #[DataProvider('provide_attributes_can_set_attributes_correctly')]
+    public function test_attributes_can_set_attributes_correctly(array|null $attributes): void
+    {
+        Colorizer::attributes($attributes);
+        $this->assertSame($attributes, Colorizer::attributes());
+        $this->assertSame($attributes, Colorizer::config()['attributes']);
+    }
+
+    public static function provide_foreground_can_set_foreground_color_correctly(): array
+    {
+        return [
+            '""' => ['foreground' => ""],
+            '"blud"' => ['foreground' => "blud"],
+            'Foreground::Red' => ['foreground' => Foreground::Red],
+            '128' => ['foreground' => 128],
+            '[0, 128, 255]' => ['foreground' => [0, 128, 255]],
+        ];
+    }
+
+    #[DataProvider('provide_foreground_can_set_foreground_color_correctly')]
+    public function test_foreground_can_set_foreground_color_correctly(string|Foreground|int|array $foreground): void
+    {
+        Colorizer::foreground($foreground);
+        $this->assertSame($foreground, Colorizer::foreground());
+        $this->assertSame($foreground, Colorizer::config()['foreground']);
+    }
+
+    public static function provide_background_can_set_background_color_correctly(): array
+    {
+        return [
+            '""' => ['background' => ""],
+            '"yellow"' => ['background' => "yellow"],
+            'Background::Cyan' => ['background' => Background::Cyan],
+            '128' => ['background' => 128],
+            '[0, 128, 255]' => ['background' => [0, 128, 255]],
+        ];
+    }
+
+    #[DataProvider('provide_background_can_set_background_color_correctly')]
+    public function test_background_can_set_background_color_correctly(string|Background|int|array $background): void
+    {
+        Colorizer::background($background);
+        $this->assertSame($background, Colorizer::background());
+        $this->assertSame($background, Colorizer::config()['background']);
+    }
+
     public static function provide_codes_can_return_codes_correctly(): array
     {
         return [
@@ -21,6 +124,8 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '',
             ],
+
+            // cases for attributes
             'empty attributes' => [
                 'config' => [
                     'attributes' => [],
@@ -33,9 +138,57 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '',
             ],
-            'invalid as arguments' => [
+            'invalid string as arguments' => [
                 'config' => [
                     'attributes' => ['invalid'],
+                ],
+                'expected' => '',
+            ],
+            'invalid enum as arguments' => [
+                'config' => [
+                    'attributes' => [Foreground::Green],
+                ],
+                'expected' => '',
+            ],
+            'true as arguments' => [
+                'config' => [
+                    'attributes' => [true],
+                ],
+                'expected' => '',
+            ],
+            'false as arguments' => [
+                'config' => [
+                    'attributes' => [false],
+                ],
+                'expected' => '',
+            ],
+            'int as arguments' => [
+                'config' => [
+                    'attributes' => [1],
+                ],
+                'expected' => '',
+            ],
+            'float as arguments' => [
+                'config' => [
+                    'attributes' => [1.5],
+                ],
+                'expected' => '',
+            ],
+            'array as arguments' => [
+                'config' => [
+                    'attributes' => [["bold"]],
+                ],
+                'expected' => '',
+            ],
+            'object as arguments' => [
+                'config' => [
+                    'attributes' => [new \stdClass()],
+                ],
+                'expected' => '',
+            ],
+            'closuer as arguments' => [
+                'config' => [
+                    'attributes' => [fn () => "bold"],
                 ],
                 'expected' => '',
             ],
@@ -81,6 +234,8 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '1;3',
             ],
+
+            // cases for foreground
             'empty foreground' => [
                 'config' => [
                     'foreground' => '',
@@ -99,6 +254,48 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '',
             ],
+            'true as foreground' => [
+                'config' => [
+                    'foreground' => true,
+                ],
+                'expected' => '',
+            ],
+            'false as foreground' => [
+                'config' => [
+                    'foreground' => false,
+                ],
+                'expected' => '',
+            ],
+            'float as foreground' => [
+                'config' => [
+                    'foreground' => 1.5,
+                ],
+                'expected' => '',
+            ],
+            'object as foreground' => [
+                'config' => [
+                    'foreground' => new \stdClass(),
+                ],
+                'expected' => '',
+            ],
+            'closure as foreground' => [
+                'config' => [
+                    'foreground' => fn () => "blue",
+                ],
+                'expected' => '',
+            ],
+            'Attribute enum as foreground' => [
+                'config' => [
+                    'foreground' => Attribute::Bold,
+                ],
+                'expected' => '',
+            ],
+            'Background enum as foreground' => [
+                'config' => [
+                    'foreground' => Background::Red,
+                ],
+                'expected' => '',
+            ],
             'yellow as foreground' => [
                 'config' => [
                     'foreground' => 'yellow',
@@ -111,6 +308,74 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '33',
             ],
+            'int -1 as foreground' => [
+                'config' => [
+                    'foreground' => -1,
+                ],
+                'expected' => '38;5;0',
+            ],
+            'int 0 as foreground' => [
+                'config' => [
+                    'foreground' => 0,
+                ],
+                'expected' => '38;5;0',
+            ],
+            'int 1 as foreground' => [
+                'config' => [
+                    'foreground' => 1,
+                ],
+                'expected' => '38;5;1',
+            ],
+            'int 254 as foreground' => [
+                'config' => [
+                    'foreground' => 254,
+                ],
+                'expected' => '38;5;254',
+            ],
+            'int 255 as foreground' => [
+                'config' => [
+                    'foreground' => 255,
+                ],
+                'expected' => '38;5;255',
+            ],
+            'int 256 as foreground' => [
+                'config' => [
+                    'foreground' => 256,
+                ],
+                'expected' => '38;5;255',
+            ],
+            '[null] as foreground' => [
+                'config' => [
+                    'foreground' => [null],
+                ],
+                'expected' => '38;2;0;0;0',
+            ],
+            '[64] as foreground' => [
+                'config' => [
+                    'foreground' => [64],
+                ],
+                'expected' => '38;2;64;0;0',
+            ],
+            '[64, 128] as foreground' => [
+                'config' => [
+                    'foreground' => [64, 128],
+                ],
+                'expected' => '38;2;64;128;0',
+            ],
+            '[64, 128, 192] as foreground' => [
+                'config' => [
+                    'foreground' => [64, 128, 192],
+                ],
+                'expected' => '38;2;64;128;192',
+            ],
+            '[64, 128, 192, 255] as foreground' => [
+                'config' => [
+                    'foreground' => [64, 128, 192, 255],
+                ],
+                'expected' => '38;2;64;128;192',
+            ],
+
+            // cases for background
             'empty as background' => [
                 'config' => [
                     'background' => '',
@@ -129,6 +394,48 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '',
             ],
+            'true as background' => [
+                'config' => [
+                    'background' => true,
+                ],
+                'expected' => '',
+            ],
+            'false as background' => [
+                'config' => [
+                    'background' => false,
+                ],
+                'expected' => '',
+            ],
+            'float as background' => [
+                'config' => [
+                    'background' => 1.5,
+                ],
+                'expected' => '',
+            ],
+            'object as background' => [
+                'config' => [
+                    'background' => new \stdClass(),
+                ],
+                'expected' => '',
+            ],
+            'closure as background' => [
+                'config' => [
+                    'background' => fn () => "magenta",
+                ],
+                'expected' => '',
+            ],
+            'Attribute enum as background' => [
+                'config' => [
+                    'background' => Attribute::Italic,
+                ],
+                'expected' => '',
+            ],
+            'Foregound enum as background' => [
+                'config' => [
+                    'background' => Foreground::Cyan,
+                ],
+                'expected' => '',
+            ],
             'green as background' => [
                 'config' => [
                     'background' => 'green',
@@ -141,6 +448,74 @@ final class ColorizerTest extends TestCase
                 ],
                 'expected' => '42',
             ],
+            'int -1 as background' => [
+                'config' => [
+                    'background' => -1,
+                ],
+                'expected' => '48;5;0',
+            ],
+            'int 0 as background' => [
+                'config' => [
+                    'background' => 0,
+                ],
+                'expected' => '48;5;0',
+            ],
+            'int 1 as background' => [
+                'config' => [
+                    'background' => 1,
+                ],
+                'expected' => '48;5;1',
+            ],
+            'int 254 as background' => [
+                'config' => [
+                    'background' => 254,
+                ],
+                'expected' => '48;5;254',
+            ],
+            'int 255 as background' => [
+                'config' => [
+                    'background' => 255,
+                ],
+                'expected' => '48;5;255',
+            ],
+            'int 256 as background' => [
+                'config' => [
+                    'background' => 256,
+                ],
+                'expected' => '48;5;255',
+            ],
+            '[null] as background' => [
+                'config' => [
+                    'background' => [null],
+                ],
+                'expected' => '48;2;0;0;0',
+            ],
+            '[64] as background' => [
+                'config' => [
+                    'background' => [64],
+                ],
+                'expected' => '48;2;64;0;0',
+            ],
+            '[64, 128] as background' => [
+                'config' => [
+                    'background' => [64, 128],
+                ],
+                'expected' => '48;2;64;128;0',
+            ],
+            '[64, 128, 192] as background' => [
+                'config' => [
+                    'background' => [64, 128, 192],
+                ],
+                'expected' => '48;2;64;128;192',
+            ],
+            '[64, 128, 192, 255] as background' => [
+                'config' => [
+                    'background' => [64, 128, 192, 255],
+                ],
+                'expected' => '48;2;64;128;192',
+            ],
+
+            // combinations
             'empty attributes, foreground and background' => [
                 'config' => [
                     'attributes' => [],
@@ -236,5 +611,197 @@ final class ColorizerTest extends TestCase
     public function test_codes_can_return_codes_correctly(array $config, string $expected): void
     {
         $this->assertSame($expected, Colorizer::codes($config));
+    }
+
+    public static function provide_encode_can_return_encoded_value_correctly(): array
+    {
+        return [
+            'empty config' => [
+                'config' => [],
+                'message' => 'Hi, there!',
+                'expected' => 'Hi, there!',
+            ],
+            'bold' => [
+                'config' => [
+                    'attributes' => ["bold"],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[1mHi, there!\e[m",
+            ],
+            'italic, underline' => [
+                'config' => [
+                    'attributes' => ["italic", "underline"],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[3;4mHi, there!\e[m",
+            ],
+            'foreground:red' => [
+                'config' => [
+                    'foreground' => "red",
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[31mHi, there!\e[m",
+            ],
+            'foreground:128' => [
+                'config' => [
+                    'foreground' => 128,
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[38;5;128mHi, there!\e[m",
+            ],
+            'foreground:[0, 128, 255]' => [
+                'config' => [
+                    'foreground' => [0, 128, 255],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[38;2;0;128;255mHi, there!\e[m",
+            ],
+            'background:red' => [
+                'config' => [
+                    'background' => "red",
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[41mHi, there!\e[m",
+            ],
+            'background:128' => [
+                'config' => [
+                    'background' => 128,
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[48;5;128mHi, there!\e[m",
+            ],
+            'background:[0, 128, 255]' => [
+                'config' => [
+                    'background' => [0, 128, 255],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[48;2;0;128;255mHi, there!\e[m",
+            ],
+            'foreground:red' => [
+                'config' => [
+                    'foreground' => "red",
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[31mHi, there!\e[m",
+            ],
+            'foreground:128' => [
+                'config' => [
+                    'foreground' => 128,
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[38;5;128mHi, there!\e[m",
+            ],
+            'bold, italic, foreground:[0, 128, 255], background:[128, 255, 0]' => [
+                'config' => [
+                    'attributes' => ["bold", "italic"],
+                    'foreground' => [0, 128, 255],
+                    'background' => [128, 255, 0],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\e[1;3;38;2;0;128;255;48;2;128;255;0mHi, there!\e[m",
+            ],
+        ];
+    }
+
+    #[DataProvider('provide_encode_can_return_encoded_value_correctly')]
+    public function test_encode_can_return_encoded_value_correctly(array $config, string $message, string $expected): void
+    {
+        $this->assertSame($expected, Colorizer::config($config)->encode($message));
+    }
+
+    public static function provide_readable_can_return_readable_value_correctly(): array
+    {
+        return [
+            'empty config' => [
+                'config' => [],
+                'message' => 'Hi, there!',
+                'expected' => 'Hi, there!',
+            ],
+            'bold' => [
+                'config' => [
+                    'attributes' => ["bold"],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[1mHi, there!\\033[m",
+            ],
+            'italic, underline' => [
+                'config' => [
+                    'attributes' => ["italic", "underline"],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[3;4mHi, there!\\033[m",
+            ],
+            'foreground:red' => [
+                'config' => [
+                    'foreground' => "red",
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[31mHi, there!\\033[m",
+            ],
+            'foreground:128' => [
+                'config' => [
+                    'foreground' => 128,
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[38;5;128mHi, there!\\033[m",
+            ],
+            'foreground:[0, 128, 255]' => [
+                'config' => [
+                    'foreground' => [0, 128, 255],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[38;2;0;128;255mHi, there!\\033[m",
+            ],
+            'background:red' => [
+                'config' => [
+                    'background' => "red",
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[41mHi, there!\\033[m",
+            ],
+            'background:128' => [
+                'config' => [
+                    'background' => 128,
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[48;5;128mHi, there!\\033[m",
+            ],
+            'background:[0, 128, 255]' => [
+                'config' => [
+                    'background' => [0, 128, 255],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[48;2;0;128;255mHi, there!\\033[m",
+            ],
+            'foreground:red' => [
+                'config' => [
+                    'foreground' => "red",
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[31mHi, there!\\033[m",
+            ],
+            'foreground:128' => [
+                'config' => [
+                    'foreground' => 128,
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[38;5;128mHi, there!\\033[m",
+            ],
+            'bold, italic, foreground:[0, 128, 255], background:[128, 255, 0]' => [
+                'config' => [
+                    'attributes' => ["bold", "italic"],
+                    'foreground' => [0, 128, 255],
+                    'background' => [128, 255, 0],
+                ],
+                'message' => 'Hi, there!',
+                'expected' => "\\033[1;3;38;2;0;128;255;48;2;128;255;0mHi, there!\\033[m",
+            ],
+        ];
+    }
+
+    #[DataProvider('provide_readable_can_return_readable_value_correctly')]
+    public function test_readable_can_return_readable_value_correctly(array $config, string $message, string $expected): void
+    {
+        $this->assertSame($expected, Colorizer::config($config)->readable($message));
     }
 }


### PR DESCRIPTION
This PR:

- Fixes PHPDoc annotations and return types of some functions
- Refactors `Colorizer::encode()` not to include escape sequences when no configuration is set.
- Adds test cases.
- Updates README